### PR TITLE
Pierce/vmas multiple motion models

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,15 +402,15 @@ To create a fake screen you need to have `Xvfb` installed.
 
 ## TODOS
 
-- [ ] Improve VMAS performance
-- [X] Dict obs support in torchrl
-- [X] Make TextLine a Geom usable in a scenario
-- [ ] Implement 2D birds eye view camera sensor
-- [X] Notebook on how to use torch rl with vmas
 - [ ] Reset any number of dimensions
 - [ ] Improve test efficiency and add new tests
 - [ ] Implement 1D camera sensor
 - [ ] Allow any number of actions
+- [ ] Implement 2D birds eye view camera sensor
+- [X] Improve VMAS performance
+- [X] Dict obs support in torchrl
+- [X] Make TextLine a Geom usable in a scenario
+- [X] Notebook on how to use torch rl with vmas
 - [X] Allow dict obs spaces and multidim obs
 - [X] Talk about action preprocessing and velocity controller
 - [X] New envs from joint project with their descriptions

--- a/README.md
+++ b/README.md
@@ -405,8 +405,9 @@ To create a fake screen you need to have `Xvfb` installed.
 - [ ] Reset any number of dimensions
 - [ ] Improve test efficiency and add new tests
 - [ ] Implement 1D camera sensor
-- [ ] Allow any number of actions
 - [ ] Implement 2D birds eye view camera sensor
+- [ ] Implement 2D drone dynamics
+- [X] Allow any number of actions
 - [X] Improve VMAS performance
 - [X] Dict obs support in torchrl
 - [X] Make TextLine a Geom usable in a scenario

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2022-2023.
+#  Copyright (c) 2022-2024.
 #  ProrokLab (https://www.proroklab.org/)
 #  All rights reserved.
 
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="vmas",
-    version="1.3.3",
+    version="1.3.4",
     description="Vectorized Multi-Agent Simulator",
     url="https://github.com/proroklab/VectorizedMultiAgentSimulator",
     license="GPLv3",

--- a/test_waypoint_tracker.py
+++ b/test_waypoint_tracker.py
@@ -1,0 +1,78 @@
+from vmas import make_env
+import numpy as np
+import torch
+
+from vmas.simulator.utils import save_video
+
+
+DEVICE="cuda"
+SEED=1
+
+env = make_env(
+    scenario="navigation",
+    num_envs=1,
+    max_steps=200,
+    device=DEVICE,
+    continuous_actions=True,
+    wrapper=None,
+    seed=SEED,
+    # Environment specific variables
+    n_agents=1,
+)
+
+obs = env.reset()
+frame_list = []
+for i in range(100):
+    if i == 0:
+        agent = env.agents[0]
+        agent.goal.state.pos = torch.tensor([[0.0, 1.0]])
+        agent.state.pos = torch.tensor([[0.0, 0.0]])
+        # agent.state.rot = torch.tensor([[0.0]]) # this doesn't work
+
+    # print(i)
+    # act once for each agent
+    act = []
+    for i, agent in enumerate(env.agents):
+
+        # find goal w.r.t robot frame (difference given in global frame)
+        # robot frame = FLU
+        rel_pose_to_goal = agent.goal.state.pos - agent.state.pos
+        goal_x_global = rel_pose_to_goal[:, 0]
+        goal_y_global = rel_pose_to_goal[:, 1]
+        agent_x_global = agent.state.pos[:, 0]
+        agent_y_global = agent.state.pos[:, 1]
+        theta_robot_to_global = -agent.state.rot
+
+        # print(f'({agent_x_global.item()}, {agent_y_global.item()})')
+        # print("agent state")
+        # print(agent_x_global, agent_y_global, theta_robot_to_global)
+        # print("rel goal global")
+        # print(goal_x_global, goal_y_global)
+        
+        goal_x_robot = goal_x_global * torch.cos(theta_robot_to_global) - goal_y_global * torch.sin(theta_robot_to_global)
+        goal_y_robot = goal_x_global * torch.sin(theta_robot_to_global) + goal_y_global * torch.cos(theta_robot_to_global)
+
+        # print("goal_robot_coords", goal_x_robot, goal_y_robot)
+
+        to_goal = torch.cat([goal_x_robot, goal_y_robot], dim=1)
+        # print("to goal", to_goal)
+
+        action = to_goal
+        action = (to_goal / torch.linalg.norm(to_goal)) * 1e-1
+        # action = torch.tensor([[0.00, 0.01]])
+        print("raw action input", action)
+        act.append(action)
+
+    next, rew, done, info = env.step(act)
+
+    frame = env.render(
+        mode="rgb_array",
+        visualize_when_rgb=True,
+    )
+    frame_list.append(frame)
+
+save_video(
+    "test_waypoint_tracker",
+    frame_list,
+    fps=10,
+)

--- a/vmas/make_env.py
+++ b/vmas/make_env.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2022-2023.
+#  Copyright (c) 2022-2024.
 #  ProrokLab (https://www.proroklab.org/)
 #  All rights reserved.
 
@@ -22,6 +22,7 @@ def make_env(
     max_steps: Optional[int] = None,
     seed: Optional[int] = None,
     dict_spaces: bool = False,
+    multidiscrete_actions: bool = False,
     **kwargs,
 ):
     """
@@ -35,7 +36,10 @@ def make_env(
         max_steps: Maximum number of steps in each vectorized environment after which done is returned
         seed: seed
         dict_spaces:  Weather to use dictionary i/o spaces with format {agent_name: tensor}
-        for obs, rewards, and info instead of tuples.
+            for obs, rewards, and info instead of tuples.
+        multidiscrete_actions (bool): Whether to use multidiscrete_actions action spaces when continuous_actions=False.
+            Otherwise, (default) the action space will be Discrete, and it will be the cartesian product of the
+            action spaces of an agent.
         **kwargs ():
 
     Returns:
@@ -55,6 +59,7 @@ def make_env(
         max_steps=max_steps,
         seed=seed,
         dict_spaces=dict_spaces,
+        multidiscrete_actions=multidiscrete_actions,
         **kwargs,
     )
 

--- a/vmas/make_env.py
+++ b/vmas/make_env.py
@@ -23,6 +23,7 @@ def make_env(
     seed: Optional[int] = None,
     dict_spaces: bool = False,
     multidiscrete_actions: bool = False,
+    clamp_actions: bool = False,
     **kwargs,
 ):
     """
@@ -40,6 +41,8 @@ def make_env(
         multidiscrete_actions (bool): Whether to use multidiscrete_actions action spaces when continuous_actions=False.
             Otherwise, (default) the action space will be Discrete, and it will be the cartesian product of the
             action spaces of an agent.
+        clamp_actions: Weather to clamp input actions to the range instead of throwing
+            an error when continuous_actions is True and actions are out of bounds
         **kwargs ():
 
     Returns:
@@ -60,6 +63,7 @@ def make_env(
         seed=seed,
         dict_spaces=dict_spaces,
         multidiscrete_actions=multidiscrete_actions,
+        clamp_actions=clamp_actions,
         **kwargs,
     )
 

--- a/vmas/scenarios/debug/kinematic_bicycle.py
+++ b/vmas/scenarios/debug/kinematic_bicycle.py
@@ -1,3 +1,7 @@
+#  Copyright (c) 2024.
+#  ProrokLab (https://www.proroklab.org/)
+#  All rights reserved.
+
 import typing
 from typing import List
 
@@ -5,12 +9,14 @@ import torch
 
 from vmas import render_interactively
 from vmas.simulator.core import Agent, World, Box
-from vmas.simulator.dynamics.kinematic_bicycle import KinematicBicycleDynamics
+from vmas.simulator.dynamics.holonomic_with_rot import HolonomicWithRotation
+from vmas.simulator.dynamics.kinematic_bicycle import KinematicBicycle
 from vmas.simulator.scenario import BaseScenario
 from vmas.simulator.utils import Color, ScenarioUtils
 
 if typing.TYPE_CHECKING:
     from vmas.simulator.rendering import Geom
+
 
 class Scenario(BaseScenario):
     def make_world(self, batch_dim: int, device: torch.device, **kwargs):
@@ -18,38 +24,48 @@ class Scenario(BaseScenario):
         Kinematic bicycle model example scenario
         """
         self.n_agents = kwargs.get("n_agents", 2)
-        width = kwargs.get("width", 0.1) # Agent width
-        l_f = kwargs.get("l_f", 0.1) # Distance between the front axle and the center of gravity
-        l_r = kwargs.get("l_r", 0.1) # Distance between the rear axle and the center of gravity
-        max_steering_angle = kwargs.get("max_steering_angle", torch.deg2rad(torch.tensor(30.0)))
+        width = kwargs.get("width", 0.1)  # Agent width
+        l_f = kwargs.get(
+            "l_f", 0.1
+        )  # Distance between the front axle and the center of gravity
+        l_r = kwargs.get(
+            "l_r", 0.1
+        )  # Distance between the rear axle and the center of gravity
+        max_steering_angle = kwargs.get(
+            "max_steering_angle", torch.deg2rad(torch.tensor(30.0))
+        )
 
         # Make world
-        world = World(batch_dim, device, substeps=10)
+        world = World(batch_dim, device, substeps=10, collision_force=500)
 
         for i in range(self.n_agents):
             if i == 0:
                 # Use the kinematic bicycle model for the first agent
                 agent = Agent(
-                    name=f"agent_{i}",
-                    shape=Box(length=l_f+l_r, width=width),
-                    collide=False, # turn off since the check of box-box collisions is quite expensive currently
+                    name=f"bicycle_{i}",
+                    shape=Box(length=l_f + l_r, width=width),
+                    collide=True,
                     render_action=True,
-                    u_range=1,
-                    u_rot_range=max_steering_angle,
-                    u_rot_multiplier=1,
-                )
-                agent.dynamics = KinematicBicycleDynamics(
-                    agent, world, width=width, l_f=l_f, l_r=l_r, max_steering_angle=max_steering_angle, integration="euler" # one of "euler", "rk4"
+                    u_range=[1, max_steering_angle],
+                    u_multiplier=[1, 1],
+                    dynamics=KinematicBicycle(
+                        world,
+                        width=width,
+                        l_f=l_f,
+                        l_r=l_r,
+                        max_steering_angle=max_steering_angle,
+                        integration="euler",  # one of "euler", "rk4"
+                    ),
                 )
             else:
                 agent = Agent(
-                    name=f"agent_{i}",
-                    shape=Box(length=l_f+l_r, width=width),
-                    collide=False,
+                    name=f"holo_rot_{i}",
+                    shape=Box(length=l_f + l_r, width=width),
+                    collide=True,
                     render_action=True,
-                    u_range=1,
-                    u_rot_range=1,
-                    u_rot_multiplier=0.001,
+                    u_range=[1, 1, 1],
+                    u_multiplier=[1, 1, 0.001],
+                    dynamics=HolonomicWithRotation(),
                 )
 
             world.add_agent(agent)
@@ -65,13 +81,6 @@ class Scenario(BaseScenario):
             x_bounds=(-1, 1),
             y_bounds=(-1, 1),
         )
-
-    def process_action(self, agent: Agent):
-        if hasattr(agent, 'dynamics') and hasattr(agent.dynamics, 'process_force'):
-            agent.dynamics.process_force()
-        else:
-            # The agent does not have a dynamics property, or it does not have a process_force method
-            pass
 
     def reward(self, agent: Agent):
         return torch.zeros(self.world.batch_dim)
@@ -108,6 +117,14 @@ class Scenario(BaseScenario):
 
         return geoms
 
+
 # ... and the code to run the simulation.
 if __name__ == "__main__":
-    render_interactively(__file__, control_two_agents=True, width=0.1, l_f=0.1, l_r=0.1, display_info=True)
+    render_interactively(
+        __file__,
+        control_two_agents=True,
+        width=0.1,
+        l_f=0.1,
+        l_r=0.1,
+        display_info=True,
+    )

--- a/vmas/scenarios/dispersion.py
+++ b/vmas/scenarios/dispersion.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2022-2023.
+#  Copyright (c) 2022-2024.
 #  ProrokLab (https://www.proroklab.org/)
 #  All rights reserved.
 
@@ -15,11 +15,14 @@ class Scenario(BaseScenario):
         n_agents = kwargs.get("n_agents", 4)
         self.share_reward = kwargs.get("share_reward", False)
         self.penalise_by_time = kwargs.get("penalise_by_time", False)
-
-        n_food = n_agents
+        self.food_radius = kwargs.get("food_radius", 0.05)
+        self.pos_range = kwargs.get("pos_range", 1.0)
+        n_food = kwargs.get("n_food", n_agents)
 
         # Make world
-        world = World(batch_dim, device)
+        world = World(
+            batch_dim, device, x_semidim=self.pos_range, y_semidim=self.pos_range
+        )
         # Add agents
         for i in range(n_agents):
             # Constraint: all agents have same action range and multiplier
@@ -32,9 +35,9 @@ class Scenario(BaseScenario):
         # Add landmarks
         for i in range(n_food):
             food = Landmark(
-                name=f"food {i}",
+                name=f"food_{i}",
                 collide=False,
-                shape=Sphere(radius=0.02),
+                shape=Sphere(radius=self.food_radius),
                 color=Color.GREEN,
             )
             world.add_landmark(food)
@@ -58,8 +61,8 @@ class Scenario(BaseScenario):
                     device=self.world.device,
                     dtype=torch.float32,
                 ).uniform_(
-                    -1.0,
-                    1.0,
+                    -self.pos_range,
+                    self.pos_range,
                 ),
                 batch_index=env_index,
             )

--- a/vmas/scenarios/mpe/simple_crypto.py
+++ b/vmas/scenarios/mpe/simple_crypto.py
@@ -181,10 +181,10 @@ class Scenario(BaseScenario):
                     key,
                 ],
                 dim=-1,
-            )
+            ).to(torch.float)
         # listener
         if not agent.speaker and not agent.adversary:
-            return torch.cat([key, *comm], dim=-1)
+            return torch.cat([key, *comm], dim=-1).to(torch.float)
         # adv
         if not agent.speaker and agent.adversary:
-            return torch.cat([*comm], dim=-1)
+            return torch.cat([*comm], dim=-1).to(torch.float)

--- a/vmas/scenarios/navigation.py
+++ b/vmas/scenarios/navigation.py
@@ -52,13 +52,13 @@ class Scenario(BaseScenario):
 
         self.robots_file = kwargs.get("robots",
                                  {'name': 'robots_0', # name of the robots file/pool
-                                  'robots': {
+                                  'robots':
                                       # list of robots in the robot pool
                                       [ 
                                           {'id': "01", 'dynamics': 'holonomic'},
                                           {'id': "10", 'dynamics': 'differential'}
                                       ]
-                                  }})
+                                  })
 
         assert 1 <= self.agents_with_same_goal <= self.n_agents
         if self.agents_with_same_goal > 1:

--- a/vmas/scenarios/navigation.py
+++ b/vmas/scenarios/navigation.py
@@ -103,7 +103,7 @@ class Scenario(BaseScenario):
         
         # Add agents
         self.agent_list = []
-        for robot in self.robots:
+        for i, robot in enumerate(self.robots):
             agent_id = robot['id']
             agent_dynamics = robot['dynamics']
             sensors=[Lidar(world,
@@ -115,7 +115,7 @@ class Scenario(BaseScenario):
 
             if agent_dynamics == 'holonomic':
                 agent = Agent(
-                    name=f"agent_{agent_id}_holo",
+                    name=f"agent_holo-{agent_id}",
                     collide=True,
                     color=color,
                     shape=Sphere(0.1),
@@ -128,7 +128,7 @@ class Scenario(BaseScenario):
                 
             elif agent_dynamics == 'differential':
                 agent = Agent(
-                    name=f"agent_{agent_id}_diff",
+                    name=f"agent_diff-{agent_id}",
                     collide=True,
                     color=color,
                     shape=Sphere(0.1),
@@ -142,7 +142,7 @@ class Scenario(BaseScenario):
                 width, l_f, l_r = 0.1, 0.1, 0.1
                 max_steering_angle = torch.deg2rad(torch.tensor(30.0))
                 agent = Agent(
-                    name=f"agent_{agent_id}_bicycle",
+                    name=f"agent_bicycle-{agent_id}",
                     shape=Box(length=l_f + l_r, width=width),
                     collide=True,
                     color=color,
@@ -295,6 +295,7 @@ class Scenario(BaseScenario):
         return torch.cat(
             [
                 agent.state.pos,
+                agent.state.rot,
                 agent.state.vel,
             ]
             + goal_poses

--- a/vmas/scenarios/navigation.py
+++ b/vmas/scenarios/navigation.py
@@ -125,6 +125,12 @@ class Scenario(BaseScenario):
                     dynamics=Holonomic(),
                     sensors=sensors,
                 )
+                # Holonomic dynamics by default have actions
+                # as force
+                controller_params = [0.2, 0.6, 0.0002]
+                agent.controller = VelocityController(
+                agent, world, controller_params, "standard"
+            )
                 
             elif agent_dynamics == 'differential':
                 agent = Agent(
@@ -139,8 +145,9 @@ class Scenario(BaseScenario):
                     sensors=sensors,
                 )
             elif agent_dynamics == 'bicycle':
-                width, l_f, l_r = 0.1, 0.1, 0.1
-                max_steering_angle = torch.deg2rad(torch.tensor(30.0))
+                # width, l_f, l_r = 0.1, 0.1, 0.1
+                width, l_f, l_r = robot.get('width'), robot.get('l_f'), robot.get('l_r')
+                max_steering_angle = torch.deg2rad(torch.tensor(40.0))
                 agent = Agent(
                     name=f"agent_bicycle-{agent_id}",
                     shape=Box(length=l_f + l_r, width=width),
@@ -165,10 +172,6 @@ class Scenario(BaseScenario):
             agent.pos_rew = torch.zeros(batch_dim, device=device)
             agent.agent_collision_rew = agent.pos_rew.clone()
 
-            controller_params = [0.2, 0.6, 0.0002]
-            agent.controller = VelocityController(
-                agent, world, controller_params, "standard"
-            )
 
             # Add goals
             goal = Landmark(

--- a/vmas/scenarios/navigation.py
+++ b/vmas/scenarios/navigation.py
@@ -13,6 +13,7 @@ from vmas.simulator.heuristic_policy import BaseHeuristicPolicy
 from vmas.simulator.scenario import BaseScenario
 from vmas.simulator.sensors import Lidar
 from vmas.simulator.utils import Color, ScenarioUtils, X, Y
+from vmas.simulator.dynamics.waypoint_tracker import WaypointTracker
 
 
 if typing.TYPE_CHECKING:
@@ -89,6 +90,9 @@ class Scenario(BaseScenario):
                 color=color,
                 shape=Sphere(radius=self.agent_radius),
                 render_action=True,
+                u_range=10,
+                u_multiplier=1,
+                dynamics=WaypointTracker(world),
                 sensors=[
                     Lidar(
                         world,

--- a/vmas/scenarios/reverse_transport.py
+++ b/vmas/scenarios/reverse_transport.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2022-2023.
+#  Copyright (c) 2022-2024.
 #  ProrokLab (https://www.proroklab.org/)
 #  All rights reserved.
 
@@ -21,7 +21,9 @@ class Scenario(BaseScenario):
         self.shaping_factor = 100
 
         # Make world
-        world = World(batch_dim, device, contact_margin=6e-3)
+        world = World(
+            batch_dim, device, contact_margin=6e-3, substeps=5, collision_force=500
+        )
         # Add agents
         for i in range(n_agents):
             agent = Agent(name=f"agent_{i}", shape=Sphere(0.03), u_multiplier=0.5)

--- a/vmas/simulator/core.py
+++ b/vmas/simulator/core.py
@@ -290,7 +290,7 @@ class EntityState(TorchVectorizedObject):
                 else:
                     attr[env_index] = 0.0
 
-    def _spawn(self, dim_c: int, dim_p: int, dim_capability: int):
+    def _spawn(self, dim_c: int, dim_p: int, dim_capability: int=None):
         self.pos = torch.zeros(
             self.batch_dim, dim_p, device=self.device, dtype=torch.float32
         )

--- a/vmas/simulator/core.py
+++ b/vmas/simulator/core.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2022-2023.
+#  Copyright (c) 2022-2024.
 #  ProrokLab (https://www.proroklab.org/)
 #  All rights reserved.
 
@@ -7,10 +7,13 @@ from __future__ import annotations
 import math
 import typing
 from abc import ABC, abstractmethod
-from typing import Callable, List, Tuple
+from typing import Callable, List, Tuple, Union, Sequence
 
 import torch
 from torch import Tensor
+
+from vmas.simulator.dynamics.common import Dynamics
+from vmas.simulator.dynamics.holonomic import Holonomic
 from vmas.simulator.joints import Joint
 from vmas.simulator.physics import (
     _get_closest_point_line,
@@ -308,6 +311,10 @@ class AgentState(EntityState):
         super().__init__()
         # communication utterance
         self._c = None
+        # Agent force from actions
+        self._force = None
+        # Agent torque from actions
+        self._torque = None
 
     @property
     def c(self):
@@ -324,9 +331,39 @@ class AgentState(EntityState):
 
         self._c = c.to(self._device)
 
+    @property
+    def force(self):
+        return self._force
+
+    @force.setter
+    def force(self, value):
+        assert (
+            self._batch_dim is not None and self._device is not None
+        ), "First add an entity to the world before setting its state"
+        assert (
+            value.shape[0] == self._batch_dim
+        ), f"Internal state must match batch dim, got {value.shape[0]}, expected {self._batch_dim}"
+
+        self._force = value.to(self._device)
+
+    @property
+    def torque(self):
+        return self._torque
+
+    @torque.setter
+    def torque(self, value):
+        assert (
+            self._batch_dim is not None and self._device is not None
+        ), "First add an entity to the world before setting its state"
+        assert (
+            value.shape[0] == self._batch_dim
+        ), f"Internal state must match batch dim, got {value.shape[0]}, expected {self._batch_dim}"
+
+        self._torque = value.to(self._device)
+
     @override(EntityState)
     def _reset(self, env_index: typing.Optional[int]):
-        for attr in [self.c]:
+        for attr in [self.c, self.force, self.torque]:
             if attr is not None:
                 if env_index is None:
                     attr[:] = 0.0
@@ -340,6 +377,12 @@ class AgentState(EntityState):
             self.c = torch.zeros(
                 self.batch_dim, dim_c, device=self.device, dtype=torch.float32
             )
+        self.force = torch.zeros(
+            self.batch_dim, dim_p, device=self.device, dtype=torch.float32
+        )
+        self.torque = torch.zeros(
+            self.batch_dim, 1, device=self.device, dtype=torch.float32
+        )
         super()._spawn(dim_c, dim_p)
 
 
@@ -347,12 +390,10 @@ class AgentState(EntityState):
 class Action(TorchVectorizedObject):
     def __init__(
         self,
-        u_range: float,
-        u_multiplier: float,
-        u_noise: float,
-        u_rot_range: float,
-        u_rot_multiplier: float,
-        u_rot_noise: float,
+        u_range: Union[float, Sequence[float]],
+        u_multiplier: Union[float, Sequence[float]],
+        u_noise: Union[float, Sequence[float]],
+        action_size: int,
     ):
         super().__init__()
         # physical motor noise amount
@@ -361,20 +402,27 @@ class Action(TorchVectorizedObject):
         self._u_range = u_range
         # agent action is a force multiplied by this amount
         self._u_multiplier = u_multiplier
-
-        # physical motor noise amount
-        self._u_rot_noise = u_rot_noise
-        # control range
-        self._u_rot_range = u_rot_range
-        # agent action is a force multiplied by this amount
-        self._u_rot_multiplier = u_rot_multiplier
+        # Number of actions
+        self.action_size = action_size
 
         # physical action
         self._u = None
-        # rotation action
-        self._u_rot = None
         # communication_action
         self._c = None
+
+        self._u_range_tensor = None
+        self._u_multiplier_tensor = None
+        self._u_noise_tensor = None
+
+        self._check_action_init()
+
+    def _check_action_init(self):
+        for attr in (self.u_multiplier, self.u_range, self.u_noise):
+            if isinstance(attr, List):
+                assert len(attr) == self.action_size, (
+                    f"Action attributes u_... must be either a float or a list of floats"
+                    f" (one per action) all with same length"
+                )
 
     @property
     def u(self):
@@ -390,21 +438,6 @@ class Action(TorchVectorizedObject):
         ), f"Action must match batch dim, got {u.shape[0]}, expected {self._batch_dim}"
 
         self._u = u.to(self._device)
-
-    @property
-    def u_rot(self):
-        return self._u_rot
-
-    @u_rot.setter
-    def u_rot(self, u_rot: Tensor):
-        assert (
-            self._batch_dim is not None and self._device is not None
-        ), "First add an agent to the world before setting its action"
-        assert (
-            u_rot.shape[0] == self._batch_dim
-        ), f"Action must match batch dim, got {u_rot.shape[0]}, expected {self._batch_dim}"
-
-        self._u_rot = u_rot.to(self._device)
 
     @property
     def c(self):
@@ -434,19 +467,31 @@ class Action(TorchVectorizedObject):
         return self._u_noise
 
     @property
-    def u_rot_range(self):
-        return self._u_rot_range
+    def u_range_tensor(self):
+        if self._u_range_tensor is None:
+            self._u_range_tensor = self._to_tensor(self.u_range)
+        return self._u_range_tensor
 
     @property
-    def u_rot_multiplier(self):
-        return self._u_rot_multiplier
+    def u_multiplier_tensor(self):
+        if self._u_multiplier_tensor is None:
+            self._u_multiplier_tensor = self._to_tensor(self.u_multiplier)
+        return self._u_multiplier_tensor
 
     @property
-    def u_rot_noise(self):
-        return self._u_rot_noise
+    def u_noise_tensor(self):
+        if self._u_noise_tensor is None:
+            self._u_noise_tensor = self._to_tensor(self.u_noise)
+        return self._u_noise_tensor
+
+    def _to_tensor(self, value):
+        return torch.tensor(
+            value if isinstance(value, Sequence) else [value] * self.action_size,
+            device=self.device,
+        )
 
     def _reset(self, env_index: typing.Optional[int]):
-        for attr in [self.u, self.u_rot, self.c]:
+        for attr in [self.u, self.c]:
             if attr is not None:
                 if env_index is None:
                     attr[:] = 0.0
@@ -761,15 +806,12 @@ class Agent(Entity):
         alpha: float = 0.5,
         obs_range: float = None,
         obs_noise: float = None,
-        u_noise: float = None,
-        u_range: float = 1.0,
-        u_multiplier: float = 1.0,
-        u_rot_noise: float = None,
-        u_rot_range: float = 0.0,
-        u_rot_multiplier: float = 1.0,
+        u_noise: Union[float, Sequence[float]] = 0.0,
+        u_range: Union[float, Sequence[float]] = 1.0,
+        u_multiplier: Union[float, Sequence[float]] = 1.0,
         action_script: Callable[[Agent, World], None] = None,
         sensors: List[Sensor] = None,
-        c_noise: float = None,
+        c_noise: float = 0.0,
         silent: bool = True,
         adversary: bool = False,
         drag: float = None,
@@ -778,6 +820,8 @@ class Agent(Entity):
         gravity: float = None,
         collision_filter: Callable[[Entity], bool] = lambda _: True,
         render_action: bool = False,
+        dynamics: Dynamics = None,  # Defaults to holonomic
+        action_size: int = None,
     ):
         super().__init__(
             name,
@@ -827,15 +871,20 @@ class Agent(Entity):
         # Render alpha
         self._alpha = alpha
 
-        # action
+        # Dynamics
+        self.dynamics = dynamics if dynamics is not None else Holonomic()
+        # Action
+        self.action_size = (
+            action_size if action_size is not None else self.dynamics.needed_action_size
+        )
+        self.dynamics.agent = self
         self._action = Action(
             u_range=u_range,
             u_multiplier=u_multiplier,
             u_noise=u_noise,
-            u_rot_range=u_rot_range,
-            u_rot_multiplier=u_rot_multiplier,
-            u_rot_noise=u_rot_noise,
+            action_size=self.action_size,
         )
+
         # state
         self._state = AgentState()
 
@@ -864,28 +913,15 @@ class Agent(Entity):
         assert (
             self._action.u.shape[1] == world.dim_p
         ), f"Scripted physical action of agent {self.name} has wrong shape"
+
         assert (
-            (self._action.u / self.u_multiplier).abs() <= self.u_range
+            (self._action.u / self.action.u_multiplier_tensor).abs()
+            <= self.action.u_range_tensor
         ).all(), f"Scripted physical action of {self.name} is out of range"
-        if self.u_rot_range != 0:
-            assert (
-                self._action.u_rot is not None
-            ), f"Action script of {self.name} should set u_rot action"
-            assert (
-                self._action.u_rot.shape[1] == 1
-            ), f"Scripted physical rotation action of agent {self.name} has wrong shape"
-            assert (
-                (self._action.u_rot / self._action.u_rot_multiplier).abs()
-                <= self.u_rot_range
-            ).all(), f"Scripted physical rotation action of {self.name} is out of range"
 
     @property
     def u_range(self):
         return self.action.u_range
-
-    @property
-    def u_rot_range(self):
-        return self.action.u_rot_range
 
     @property
     def obs_noise(self):
@@ -898,10 +934,6 @@ class Agent(Entity):
     @property
     def u_multiplier(self):
         return self.action.u_multiplier
-
-    @property
-    def u_rot_multiplier(self):
-        return self.action.u_rot_multiplier
 
     @property
     def max_f(self):
@@ -952,6 +984,7 @@ class Agent(Entity):
     @override(Entity)
     def _reset(self, env_index: int):
         self.action._reset(env_index)
+        self.dynamics.reset(env_index)
         super()._reset(env_index)
 
     @override(Entity)
@@ -973,11 +1006,11 @@ class Agent(Entity):
         if self._sensors is not None:
             for sensor in self._sensors:
                 geoms += sensor.render(env_index=env_index)
-        if self._render_action and self.action.u is not None:
+        if self._render_action and self.state.force is not None:
             velocity = rendering.Line(
                 self.state.pos[env_index],
                 self.state.pos[env_index]
-                + self.action.u[env_index] * 10 * self.shape.circumscribed_radius(),
+                + self.state.force[env_index] * 10 * self.shape.circumscribed_radius(),
                 width=2,
             )
             velocity.set_color(*self.color)
@@ -1503,10 +1536,11 @@ class World(TorchVectorizedObject):
             self.torque[:] = 0
 
             for i, entity in enumerate(self.entities):
-                # apply agent force controls
-                self._apply_action_force(entity, i)
-                # apply agent torque controls
-                self._apply_action_torque(entity, i)
+                if isinstance(entity, Agent):
+                    # apply agent force controls
+                    self._apply_action_force(entity, i)
+                    # apply agent torque controls
+                    self._apply_action_torque(entity, i)
                 # apply friction
                 self._apply_friction_force(entity, i)
                 # apply gravity
@@ -1526,57 +1560,30 @@ class World(TorchVectorizedObject):
                 self._update_comm_state(agent)
 
     # gather agent action forces
-    def _apply_action_force(self, entity: Entity, index: int):
-        if isinstance(entity, Agent):
-            # set applied forces
-            if entity.movable:
-                noise = (
-                    torch.randn(
-                        *entity.action.u.shape, device=self.device, dtype=torch.float32
-                    )
-                    * entity.u_noise
-                    if entity.u_noise
-                    else 0.0
+    def _apply_action_force(self, agent: Agent, index: int):
+        if agent.movable:
+            if agent.max_f is not None:
+                agent.state.force = TorchUtils.clamp_with_norm(
+                    agent.state.force, agent.max_f
                 )
-                entity.action.u += noise
-                if entity.max_f is not None:
-                    entity.action.u = TorchUtils.clamp_with_norm(
-                        entity.action.u, entity.max_f
-                    )
-                if entity.f_range is not None:
-                    entity.action.u = torch.clamp(
-                        entity.action.u, -entity.f_range, entity.f_range
-                    )
-                self.force[:, index] += entity.action.u
-            assert not self.force.isnan().any()
+            if agent.f_range is not None:
+                agent.state.force = torch.clamp(
+                    agent.state.force, -agent.f_range, agent.f_range
+                )
+            self.force[:, index] += agent.state.force
 
-    def _apply_action_torque(self, entity: Entity, index: int):
-        if isinstance(entity, Agent) and entity.u_rot_range != 0:
-            # set applied forces
-            if entity.rotatable:
-                noise = (
-                    torch.randn(
-                        *entity.action.u_rot.shape,
-                        device=self.device,
-                        dtype=torch.float32,
-                    )
-                    * entity.action.u_rot_noise
-                    if entity.action.u_rot_noise
-                    else 0.0
+    def _apply_action_torque(self, agent: Agent, index: int):
+        if agent.rotatable:
+            if agent.max_t is not None:
+                agent.state.torque = TorchUtils.clamp_with_norm(
+                    agent.state.torque, agent.max_t
                 )
-                entity.action.u_rot = entity.action.u_rot + noise
-                if len(entity.action.u_rot.shape) == 1:
-                    entity.action.u_rot.unsqueeze_(-1)
-                if entity.max_t is not None:
-                    entity.action.u_rot = TorchUtils.clamp_with_norm(
-                        entity.action.u_rot, entity.max_t
-                    )
-                if entity.t_range is not None:
-                    entity.action.u_rot = torch.clamp(
-                        entity.action.u_rot, -entity.t_range, entity.t_range
-                    )
-                self.torque[:, index] += entity.action.u_rot
-            assert not self.torque.isnan().any()
+            if agent.t_range is not None:
+                agent.state.torque = torch.clamp(
+                    agent.state.torque, -agent.t_range, agent.t_range
+                )
+
+            self.torque[:, index] += agent.state.torque
 
     def _apply_gravity(self, entity: Entity, index: int):
         if entity.movable:
@@ -2387,15 +2394,7 @@ class World(TorchVectorizedObject):
     def _update_comm_state(self, agent):
         # set communication state (directly for now)
         if not agent.silent:
-            noise = (
-                torch.randn(
-                    *agent.action.c.shape, device=self.device, dtype=torch.float32
-                )
-                * agent.c_noise
-                if agent.c_noise
-                else 0.0
-            )
-            agent.state.c = agent.action.c + noise
+            agent.state.c = agent.action.c
 
     @override(TorchVectorizedObject)
     def to(self, device: torch.device):

--- a/vmas/simulator/dynamics/common.py
+++ b/vmas/simulator/dynamics/common.py
@@ -1,0 +1,45 @@
+#  Copyright (c) 2024.
+#  ProrokLab (https://www.proroklab.org/)
+#  All rights reserved.
+import abc
+from abc import ABC
+from typing import Union
+
+from torch import Tensor
+
+
+class Dynamics(ABC):
+    def __init__(
+        self,
+    ):
+        self._agent = None
+
+    def reset(self, index: Union[Tensor, int] = None):
+        pass
+
+    @property
+    def agent(self):
+        if self._agent is None:
+            raise ValueError(
+                "You need to add the dynamics to an agent during construction before accessing its properties"
+            )
+        return self._agent
+
+    @agent.setter
+    def agent(self, value):
+        if self._agent is not None:
+            raise ValueError("Agent in dynamics has already been set")
+        if value.action_size < self.needed_action_size:
+            raise ValueError(
+                f"Agent action size {value.action_size} is less than the required dynamics action size {self.needed_action_size}"
+            )
+        self._agent = value
+
+    @property
+    @abc.abstractmethod
+    def needed_action_size(self) -> int:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def process_action(self):
+        raise NotImplementedError

--- a/vmas/simulator/dynamics/holonomic.py
+++ b/vmas/simulator/dynamics/holonomic.py
@@ -1,0 +1,14 @@
+#  Copyright (c) 2022-2024.
+#  ProrokLab (https://www.proroklab.org/)
+#  All rights reserved.
+
+from vmas.simulator.dynamics.common import Dynamics
+
+
+class Holonomic(Dynamics):
+    @property
+    def needed_action_size(self) -> int:
+        return 2
+
+    def process_action(self):
+        self.agent.state.force = self.agent.action.u[:, : self.needed_action_size]

--- a/vmas/simulator/dynamics/holonomic_with_rot.py
+++ b/vmas/simulator/dynamics/holonomic_with_rot.py
@@ -1,0 +1,15 @@
+#  Copyright (c) 2022-2024.
+#  ProrokLab (https://www.proroklab.org/)
+#  All rights reserved.
+
+from vmas.simulator.dynamics.common import Dynamics
+
+
+class HolonomicWithRotation(Dynamics):
+    @property
+    def needed_action_size(self) -> int:
+        return 3
+
+    def process_action(self):
+        self.agent.state.force = self.agent.action.u[:, :2]
+        self.agent.state.torque = self.agent.action.u[:, 2].unsqueeze(-1)

--- a/vmas/simulator/dynamics/waypoint_tracker.py
+++ b/vmas/simulator/dynamics/waypoint_tracker.py
@@ -1,0 +1,71 @@
+"""
+Implements a waypoint tracker, assuming a DifferentialDrive robot.
+
+Waypoints are given as relative position and heading, or u=(dx, dy, dtheta).
+"""
+
+import math
+
+import torch
+
+import vmas.simulator.core
+import vmas.simulator.utils
+from vmas.simulator.dynamics.common import Dynamics
+from vmas.simulator.dynamics.diff_drive import DiffDrive
+
+
+class WaypointTracker(Dynamics):
+    def __init__(
+        self,
+        world: vmas.simulator.core.World,
+        speed=1e-1,
+    ):
+        super().__init__()
+
+        self.dt = world.dt
+        self.world = world
+        self.speed = speed
+
+    @property
+    def needed_action_size(self) -> int:
+        return 2
+
+    def process_action(self):
+        # TODO: add input queue, see VelocityController
+
+        # convert relative position (dx, dy) to (forward velocity, rotational velocity)
+        # TODO: verify FLU
+        dx = self.agent.action.u[:, 0]
+        dy = self.agent.action.u[:, 1]
+
+        # round dx/dy to zero if near 0
+        dx = torch.where(torch.abs(dx) < 1e-3, 0, dx)
+        dy = torch.where(torch.abs(dy) < 1e-3, 0, dy)
+
+        # when x is near 0, set angular_velocity to either -pi/2 or pi/2, depending on sign of y
+        # otherwise, set it to clamp(arctan(dy/dx) / dt), clamped to +/- pi
+        angular_velocity = torch.where(torch.abs(dx) < 1e-2, 
+                                       torch.sign(dy) * torch.pi/2, 
+                                       torch.clamp(torch.arctan(dy/dx) / self.dt, -torch.pi, torch.pi))
+
+        forward_velocity = dx / self.dt
+        # print("vel inputs", forward_velocity, angular_velocity)
+
+        robot_angle = self.agent.state.rot
+        linear_accel = torch.cat([forward_velocity * torch.cos(robot_angle), forward_velocity * torch.sin(robot_angle)], dim=0)  / self.dt
+        angular_accel = angular_velocity / self.dt
+        # print("accel", linear_accel, angular_accel)
+
+        # print(self.agent.mass, self.agent.moment_of_inertia)
+        linear_force = self.agent.mass * linear_accel
+        angular_force = self.agent.moment_of_inertia * angular_accel
+        print("forces", linear_force, angular_force)
+
+        force_factor = self.speed
+        self.agent.state.force[:, 0] = linear_force[0] * force_factor
+        self.agent.state.force[:, 1] = linear_force[1] * force_factor
+        self.agent.state.torque = angular_force.unsqueeze(-1) * force_factor
+
+
+
+

--- a/vmas/simulator/environment/environment.py
+++ b/vmas/simulator/environment/environment.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2022-2023.
+#  Copyright (c) 2022-2024.
 #  ProrokLab (https://www.proroklab.org/)
 #  All rights reserved.
 import random
@@ -9,6 +9,7 @@ import numpy as np
 import torch
 from gym import spaces
 from torch import Tensor
+
 from vmas.simulator.core import Agent, TorchVectorizedObject
 from vmas.simulator.scenario import BaseScenario
 import vmas.simulator.utils
@@ -41,8 +42,14 @@ class Environment(TorchVectorizedObject):
         continuous_actions: bool = True,
         seed: Optional[int] = None,
         dict_spaces: bool = False,
+        multidiscrete_actions: bool = False,
         **kwargs,
     ):
+        if multidiscrete_actions:
+            assert (
+                not continuous_actions
+            ), "When asking for multidiscrete_actions, make sure continuous_actions=False"
+
         self.scenario = scenario
         self.num_envs = num_envs
         TorchVectorizedObject.__init__(self, num_envs, torch.device(device))
@@ -57,6 +64,7 @@ class Environment(TorchVectorizedObject):
         self.reset(seed=seed)
 
         # configure spaces
+        self.multidiscrete_actions = multidiscrete_actions
         self.action_space = self.get_action_space()
         self.observation_space = self.get_observation_space()
 
@@ -291,48 +299,47 @@ class Environment(TorchVectorizedObject):
             )
 
     def get_agent_action_size(self, agent: Agent):
-        return (
-            self.world.dim_p
-            + (1 if agent.action.u_rot_range != 0 else 0)
-            + (self.world.dim_c if not agent.silent else 0)
-            if self.continuous_actions
-            else 1
-            + (1 if agent.action.u_rot_range != 0 else 0)
-            + (1 if not agent.silent else 0)
-        )
+        if self.continuous_actions:
+            return agent.action.action_size + (
+                self.world.dim_c if not agent.silent else 0
+            )
+        elif self.multidiscrete_actions:
+            return agent.action_size + (
+                1 if not agent.silent and self.world.dim_c != 0 else 0
+            )
+        else:
+            return 1
 
     def get_agent_action_space(self, agent: Agent):
         if self.continuous_actions:
             return spaces.Box(
                 low=np.array(
-                    [-agent.u_range] * self.world.dim_p
-                    + [-agent.u_rot_range] * (1 if agent.u_rot_range != 0 else 0)
+                    (-agent.action.u_range_tensor).tolist()
                     + [0] * (self.world.dim_c if not agent.silent else 0),
                     dtype=np.float32,
                 ),
                 high=np.array(
-                    [agent.u_range] * self.world.dim_p
-                    + [agent.u_rot_range] * (1 if agent.u_rot_range != 0 else 0)
+                    agent.action.u_range_tensor.tolist()
                     + [1] * (self.world.dim_c if not agent.silent else 0),
                     dtype=np.float32,
                 ),
                 shape=(self.get_agent_action_size(agent),),
                 dtype=np.float32,
             )
+        elif self.multidiscrete_actions:
+            actions = [3] * agent.action_size + (
+                [self.world.dim_c] if not agent.silent and self.world.dim_c != 0 else []
+            )
+            return spaces.MultiDiscrete(actions)
         else:
-            if (self.world.dim_c == 0 or agent.silent) and agent.u_rot_range == 0.0:
-                return spaces.Discrete(self.world.dim_p * 2 + 1)
-            else:
-                actions = (
-                    [self.world.dim_p * 2 + 1]
-                    + ([3] if agent.u_rot_range != 0 else [])
-                    + (
-                        [self.world.dim_c]
-                        if not agent.silent and self.world.dim_c != 0
-                        else []
-                    )
+            return spaces.Discrete(
+                3**agent.action_size
+                * (
+                    self.world.dim_c
+                    if not agent.silent and self.world.dim_c != 0
+                    else 1
                 )
-                return spaces.MultiDiscrete(actions)
+            )
 
     def get_agent_observation_space(self, agent: Agent, obs: AGENT_OBS_TYPE):
         if isinstance(obs, Tensor):
@@ -365,7 +372,7 @@ class Environment(TorchVectorizedObject):
         action = action.clone().detach().to(self.device)
         assert not action.isnan().any()
         agent.action.u = torch.zeros(
-            self.batch_dim, self.world.dim_p, device=self.device, dtype=torch.float32
+            self.batch_dim, agent.action_size, device=self.device, dtype=torch.float32
         )
 
         assert action.shape[1] == self.get_agent_action_size(agent), (
@@ -375,67 +382,66 @@ class Environment(TorchVectorizedObject):
         action_index = 0
 
         if self.continuous_actions:
-            physical_action = action[:, action_index : action_index + self.world.dim_p]
+            physical_action = action[:, action_index : action_index + agent.action_size]
             action_index += self.world.dim_p
             assert not torch.any(
-                torch.abs(physical_action) > agent.u_range
+                torch.abs(physical_action) > agent.action.u_range_tensor
             ), f"Physical actions of agent {agent.name} are out of its range {agent.u_range}"
 
             agent.action.u = physical_action.to(torch.float32)
+
         else:
-            physical_action = action[:, action_index].unsqueeze(-1)
-            action_index += 1
-            self._check_discrete_action(
-                physical_action,
-                low=0,
-                high=self.world.dim_p * 2 + 1,
-                type="physical",
-            )
-
-            arr1 = physical_action == 1
-            arr2 = physical_action == 2
-            arr3 = physical_action == 3
-            arr4 = physical_action == 4
-
-            disc_action_value = agent.u_range
-
-            agent.action.u[:, X] -= disc_action_value * arr1.squeeze(-1)
-            agent.action.u[:, X] += disc_action_value * arr2.squeeze(-1)
-            agent.action.u[:, Y] -= disc_action_value * arr3.squeeze(-1)
-            agent.action.u[:, Y] += disc_action_value * arr4.squeeze(-1)
-
-        agent.action.u *= agent.u_multiplier
-        if agent.u_rot_range != 0:
-            if self.continuous_actions:
-                physical_action = action[:, action_index].unsqueeze(-1)
-                action_index += 1
-                assert not torch.any(
-                    torch.abs(physical_action) > agent.u_rot_range
-                ), f"Physical rotation actions of agent {agent.name} are out of its range {agent.u_rot_range}"
-                agent.action.u_rot = physical_action.to(torch.float32)
-
-            else:
-                agent.action.u_rot = torch.zeros(
-                    self.batch_dim, 1, device=self.device, dtype=torch.float32
+            if not self.multidiscrete_actions:
+                # This bit of code translates the discrete action (taken from a space that
+                # is the cartesian product of all action spaces) into a multi discrete action.
+                # For example, if agent.action_size=4, it will mean that the agent will have
+                # 4 actions each with 3 possibilities (stay, decrement, increment).
+                # The env will have a space Discrete(3**4).
+                # This code will translate the action (with shape [n_envs,1] and range [0,3**4)) to an
+                # action with shape [n_envs,4] and range [0,3).
+                n_actions = self.get_agent_action_space(agent).n
+                action_range = torch.arange(n_actions, device=self.device).expand(
+                    self.world.batch_dim, n_actions
                 )
+                physical_action = action
+                action_range = torch.where(action_range == physical_action, 1.0, 0.0)
+                action_range = action_range.view(
+                    (self.world.batch_dim,)
+                    + (3,) * agent.action_size
+                    + (self.world.dim_c,)
+                    * (1 if not agent.silent and self.world.dim_c != 0 else 0)
+                )
+                action = action_range.nonzero()[:, 1:]
+
+            # Now we have an action with shape [n_envs, action_size+comms_actions]
+            for _ in range(agent.action_size):
                 physical_action = action[:, action_index].unsqueeze(-1)
-                action_index += 1
                 self._check_discrete_action(
                     physical_action,
                     low=0,
                     high=3,
-                    type="rotation",
+                    type="physical",
                 )
 
                 arr1 = physical_action == 1
                 arr2 = physical_action == 2
 
-                disc_action_value = agent.u_rot_range
+                disc_action_value = agent.action.u_range_tensor[action_index]
+                agent.action.u[:, action_index] -= disc_action_value * arr1.squeeze(-1)
+                agent.action.u[:, action_index] += disc_action_value * arr2.squeeze(-1)
 
-                agent.action.u_rot[:, 0] -= disc_action_value * arr1.squeeze(-1)
-                agent.action.u_rot[:, 0] += disc_action_value * arr2.squeeze(-1)
+                action_index += 1
 
-            agent.action.u_rot *= agent.u_rot_multiplier
+        agent.action.u *= agent.action.u_multiplier_tensor
+
+        if agent.action.u_noise > 0:
+            noise = (
+                torch.randn(
+                    *agent.action.u.shape, device=self.device, dtype=torch.float32
+                )
+                * agent.u_noise
+            )
+            agent.action.u += noise
         if self.world.dim_c > 0 and not agent.silent:
             if not self.continuous_actions:
                 comm_action = action[:, action_index:]
@@ -457,6 +463,14 @@ class Environment(TorchVectorizedObject):
                     comm_action < 0
                 ), "Comm actions are out of range [0,1]"
                 agent.action.c = comm_action
+            if agent.c_noise > 0:
+                noise = (
+                    torch.randn(
+                        *agent.action.c.shape, device=self.device, dtype=torch.float32
+                    )
+                    * agent.c_noise
+                )
+                agent.action.c += noise
 
     def render(
         self,

--- a/vmas/simulator/environment/environment.py
+++ b/vmas/simulator/environment/environment.py
@@ -9,7 +9,6 @@ import numpy as np
 import torch
 from gym import spaces
 from torch import Tensor
-
 from vmas.simulator.core import Agent, TorchVectorizedObject
 from vmas.simulator.scenario import BaseScenario
 import vmas.simulator.utils
@@ -43,6 +42,7 @@ class Environment(TorchVectorizedObject):
         seed: Optional[int] = None,
         dict_spaces: bool = False,
         multidiscrete_actions: bool = False,
+        clamp_actions: bool = False,
         **kwargs,
     ):
         if multidiscrete_actions:
@@ -60,6 +60,7 @@ class Environment(TorchVectorizedObject):
         self.max_steps = max_steps
         self.continuous_actions = continuous_actions
         self.dict_spaces = dict_spaces
+        self.clamp_action = clamp_actions
 
         self.reset(seed=seed)
 
@@ -379,6 +380,9 @@ class Environment(TorchVectorizedObject):
             f"Agent {agent.name} has wrong action size, got {action.shape[1]}, "
             f"expected {self.get_agent_action_size(agent)}"
         )
+        if self.clamp_action and self.continuous_actions:
+            action = action.clamp(-agent.action.u_range, agent.action.u_range)
+
         action_index = 0
 
         if self.continuous_actions:

--- a/vmas/simulator/scenario.py
+++ b/vmas/simulator/scenario.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2022-2023.
+#  Copyright (c) 2022-2024.
 #  ProrokLab (https://www.proroklab.org/)
 #  All rights reserved.
 import typing
@@ -63,7 +63,9 @@ class BaseScenario(ABC):
         """Do not override"""
         if agent.action_script is not None:
             agent.action_callback(self.world)
+        # Customizable action processor
         self.process_action(agent)
+        agent.dynamics.process_action()
 
     @abstractmethod
     def make_world(self, batch_dim: int, device: torch.device, **kwargs) -> World:


### PR DESCRIPTION
# Additions
- navigation supports multiple motion dynamics: holonomic, differential drive, and bicycle dynamics.
    - robots are loaded in on environment creation using a robot configuration dictionary. This dictionary is composed from hydra "robots" configuration group in the het-mamp repository

# Notes
- Once robots are loaded on environment creation, they cannot be changed. This is a result of the design of VMAS...VMAS does not support adding, removing, or editing agents after a scenario is created. When we want to change agents during training, our current best course of action is to initialize multiple environments with different robot team compositions.
- Each agents u_range is set to be [-1, 1]. Use the u_multiplier parameter to set the true force range for unique agents.